### PR TITLE
Packages the demo into a fat jar

### DIFF
--- a/simple-webserver/pom.xml
+++ b/simple-webserver/pom.xml
@@ -29,4 +29,31 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <mainClass>quicksilver.webapp.simpleserver.app.ApplicationSimpleDemo</mainClass>
+                                </manifest>
+                            </archive>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
This packages the demo into a single file which may be executed with `java -jar simple-webserver/target/webserver-1.0-SNAPSHOT-jar-with-dependencies.jar`

I believe this closes issue #6. We could create a .tar.gz or something more complex but I don't see how having a run.sh is that much easier than a single JAR to run with `java -jar`.

Note that this is just a way to bundle the demo. I guess Quicksilver itself should provide this packaging option out of the box, but since we can use Maven, other apps will just have to use this as an example and see of the Maven assembly plugin is enough.